### PR TITLE
fix: keep "default" keys in schema encoder

### DIFF
--- a/lib/avro_ex/schema/encoder.ex
+++ b/lib/avro_ex/schema/encoder.ex
@@ -41,7 +41,7 @@ defmodule AvroEx.Schema.Encoder do
     config = update_in(config.namespace, &Schema.namespace(struct, &1))
 
     data =
-      for {k, v} <- extract(struct), not empty?(v), keep?(k, config), into: %{} do
+      for {k, v} <- extract(struct), not empty?(v) or k == "default", keep?(k, config), into: %{} do
         case k do
           k when k in [:values, :items, :type] -> {k, do_encode(v, config)}
           :fields -> {k, Enum.map(v, &do_encode(&1, config))}


### PR DESCRIPTION
The comprehension that generates an encoded schema for `AvroEx.Schema.Encoder.encode_schema` is filtering out keys when the value is [falsy](https://github.com/SimpleBet/avro_ex/blob/82145038ebbdb4109dea68338e28e2f2633d3ba1/lib/avro_ex/schema/encoder.ex#L64-L67).  

This is what we want for all keys _except_ `"default"` since a Record.Field should be able to specify a `null` default value or even an empty string `""`, etc.